### PR TITLE
[BABY-9] Docker image pushed to Dockerhub

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ $ docker run --rm -p 8080:8080 babystep-api-gateway-go:latest
 $ curl localhost:8080
 Hello
 ```
+or simply, download one from Dockerhub
+```
+$ docker run --rm -p 8080:8080 zechery/babystep-api-gateway-go:v0.0.1
+$ curl localhost:8080
+Hello
+```
 
 ## API documentation
 


### PR DESCRIPTION
* https://github.com/Junyong-Suh/babystep-api-gateway-go/issues/12
* Very first Docker image pushed to DockerHub - may download and run