### PR TITLE
Root response as json

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ $ go test ./...
 ## API documentation
 
 ### /
-Returns a string "Hello"
+Returns a string {"message": "Hello"}
 ```
 $ curl localhost:8080
-Hello
+{"message": "Hello"}
 ```
 
 ### /health

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/Junyong-Suh/babystep-api-gateway-go
 
-go 1.12
+go 1.11
 
 require github.com/gorilla/mux v1.7.1

--- a/handlers/root_handler.go
+++ b/handlers/root_handler.go
@@ -5,5 +5,7 @@ import (
 )
 
 func RootHandler(w http.ResponseWriter, r *http.Request) {
-    w.Write([]byte("Hello"))
+    w.Header().Set("Content-Type", "application/json")
+    w.WriteHeader(http.StatusOK)
+    w.Write([]byte("{\"message\":\"Hello\"}"))
 }

--- a/handlers/root_handler_test.go
+++ b/handlers/root_handler_test.go
@@ -29,7 +29,7 @@ func TestRootHandler(t *testing.T) {
     }
 
     // Check the response body is what we expect.
-    expected := `Hello`
+    expected := "{\"message\":\"Hello\"}"
     if rr.Body.String() != expected {
         t.Errorf("handler returned unexpected body: got %v want %v",
             rr.Body.String(), expected)


### PR DESCRIPTION
* Updated root handler response to JSON (should be forced for all handlers in the future)
* Updated unit test and README.md accordingly
* Downgraded to Go 1.11 for now - will update back to 1.12 soon